### PR TITLE
Fix NoStacktraceFormatter

### DIFF
--- a/slacker_log_handler/__init__.py
+++ b/slacker_log_handler/__init__.py
@@ -32,6 +32,15 @@ class NoStacktraceFormatter(Formatter):
     def formatException(self, ei):
         return None
 
+    def format(self, record):
+        # Work-around for https://bugs.python.org/issue29056
+        saved_exc_text = record.exc_text
+        record.exc_text = None
+        try:
+            return super(NoStacktraceFormatter, self).format(record)
+        finally:
+            record.exc_text = saved_exc_text
+
 
 class SlackerLogHandler(Handler):
     def __init__(self, api_key, channel, stack_trace=True, username='Python logger', icon_url=None, icon_emoji=None,


### PR DESCRIPTION
This deals with a surprising gotcha in Python's logging system: the
result of formatException() is cached. If you want to ensure that a
custom formatException method is called, you need to explicitly clear
the exc_text attribute in format().

This is documented behavior, see https://bugs.python.org/issue29056
for background info.

In our setup, we had an earlier handler with a default formatter, so
NoStacktraceFormatter's method was entirely ignored.